### PR TITLE
Fix README markdown syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Google CL
+# Google CL
 
 [![Build Status](https://travis-ci.org/vinitkumar/googlecl.svg?branch=master)](https://travis-ci.org/vinitkumar/googlecl)
 


### PR DESCRIPTION
Github's now enforcing a space after the "#" for headers, so this fixes this project's README.md